### PR TITLE
Download AMI list from up-to-date data source

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2015-07-20  Nui Narongwet  <narongwet@proteus-tech.com>
+ Download AMI list from up-to-date data source
+
 2015-04-29  Nui Narongwet  <narongwet@proteus-tech.com>
  Add Trusty ami
 

--- a/profab/role/ami/ubuntu.py
+++ b/profab/role/ami/ubuntu.py
@@ -1,5 +1,7 @@
 """Plugins that allow the AMI to be chosen.
 """
+import collections
+import json
 import re
 import urllib2
 
@@ -10,20 +12,13 @@ from profab.role import Role
 class Configure(Role):
     """Ask for the specified Ubuntu release.
     """
+
     def ami(self, region, bits, size):
         """Return the AMI that was passed in to the role.
         """
         disk = 'ebs' if size == 't1.micro' else 'instance'
         amis = struct_amis_dict(self.parameter)
         return amis[str(bits)][disk].get(region, None)
-
-
-RAW_PATTERN = r"""(\w+-\w+-\d+).+\n""" \
-    r"""\s+<td><p>\s+(32|64)-\w+.+\n""" \
-    r"""\s+<td><p>\s+(\w+).+\n""" \
-    r""".+(\w\w\w-\w+)\s+</p></td>$"""
-WEBSITE = "http://uec-images.ubuntu.com/releases/%s/release/"
-COMPILED_PATTERN = re.compile(RAW_PATTERN, re.MULTILINE)
 
 
 def _fetch_html(url):
@@ -33,29 +28,54 @@ def _fetch_html(url):
     return response.read()
 
 
+Ami = collections.namedtuple('Ami', ['zone', 'bits', 'instance_type', 'ami_id'])
+
+
+def _get_ami_list(response, release):
+    id_matcher = re.compile(r'>(\w+-[0-9a-fA-F]+)</a>')
+    json_encoded = response.replace('\n', '').replace(',]', ']')
+    raw_ami_list = filter(lambda l: l[1] == release, json.loads(json_encoded)['aaData'])
+    platform_bits = dict(amd64='64', i386='32')
+
+    ami_list = []
+    for raw_ami in raw_ami_list:
+        ami_id = id_matcher.findall(raw_ami[6])[0]
+        bits = platform_bits[raw_ami[3]]
+        ami_list.append(Ami(zone=raw_ami[0],
+                            bits=bits,
+                            instance_type=_get_instance_type(raw_ami[4]),
+                            ami_id=ami_id))
+    return ami_list
+
+
+def _get_instance_type(raw_type):
+    if raw_type == 'instance-store':
+        return 'instance'
+    return raw_type
+
+
 def struct_amis_dict(release):
     """Download the AMI list HTML and parse it to find the AMI codes
     for the various versions of Ubuntu.
     """
     try:
-        html = _fetch_html(WEBSITE % release)
+        response = _fetch_html('http://cloud-images.ubuntu.com/locator/ec2/releasesTable')
     except urllib2.HTTPError, error:
         _logger.error(error.msg)
         return None
-    ami_tuple_list = COMPILED_PATTERN.findall(html)
-    if ami_tuple_list:
-        tmp = {
-            "32": {"ebs": {}, "instance": {}, "hvm": {}},
-            "64": {"ebs": {}, "instance": {}, "hvm": {}},
-        }
-        for ami_tuple in ami_tuple_list:
+    ami_list = _get_ami_list(response, release)
+    if ami_list:
+        result_dict = dict()
+        instance_types = set(map(lambda ami: ami.instance_type, ami_list))
+        for bits in ("32", "64"):
+            result_dict[bits] = {_type: {} for _type in instance_types}
+        for ami in ami_list:
             try:
-                tmp[ami_tuple[1]][ami_tuple[2]][ami_tuple[0]] = ami_tuple[3]
+                result_dict[ami.bits][ami.instance_type][ami.zone] = ami.ami_id
             except:
-                _logger.error(ami_tuple)
+                _logger.error(ami)
                 raise
-        return tmp
+        return result_dict
     else:
         _logger.error("No AMIs found in HTML")
         return None
-

--- a/profab/tests/test_server.py
+++ b/profab/tests/test_server.py
@@ -87,13 +87,13 @@ class ServerLifecycle(TestCase):
     @mock.patch('os.mkdir', lambda p: None)
     @mock.patch('profab.connection.EC2Connection', MockConnection)
     @mock.patch('profab.role.ami.ubuntu._fetch_html', lambda u:
-        '''
-<tr>
-  <td><p> us-east-1 </p></td>
-  <td><p> 64-bit </p></td>
-  <td><p> ebs </p></td>
-  <td><p> <button type="button>Launch</button> ami-63be790a </p></td>
-</tr>
+        r'''
+{ "aaData":
+[
+["us-east-1","lucid","10.04 LTS","amd64","ebs","20150427","<a href=\"https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-1e6f6176\">ami-1e6f6176</a>","aki-919dcaf8"],
+["us-east-1","lucid","10.04 LTS","i386","ebs","20150427","<a href=\"https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-1c6f6174\">ami-1c6f6174</a>","aki-8f9dcae6"],
+]
+}
         ''')
     @mock.patch('profab.server.append', start_connection)
     @mock.patch('profab.server.getaddrinfo', lambda h, p:
@@ -105,18 +105,17 @@ class ServerLifecycle(TestCase):
     def test_start_customise_bits(self):
         server = Server.start('test', ('size', 't1.micro'), ('bits', '64'))
         self.assertEqual(server.instance.instance_type, 't1.micro')
-        self.assertEqual(server.instance.image_id, 'ami-63be790a')
+        self.assertEqual(server.instance.image_id, 'ami-1e6f6176')
 
     @mock.patch('os.mkdir', lambda p: None)
     @mock.patch('profab.connection.EC2Connection', MockConnection)
     @mock.patch('profab.role.ami.ubuntu._fetch_html', lambda u:
-        '''
-<tr>
-  <td><p> us-east-1 </p></td>
-  <td><p> 32-bit </p></td>
-  <td><p> ebs </p></td>
-  <td><p> <button type="button>Launch</button> ami-c7b202ae </p></td>
-</tr>
+        r'''
+{ "aaData":
+[
+["us-east-1","lucid","10.04 LTS","i386","ebs","20150427","<a href=\"https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-1c6f6174\">ami-1c6f6174</a>","aki-8f9dcae6"],
+]
+}
         ''')
     @mock.patch('profab.server.append', start_connection)
     @mock.patch('profab.server.getaddrinfo', lambda h, p:
@@ -127,7 +126,7 @@ class ServerLifecycle(TestCase):
     @mock.patch('time.sleep', lambda s: None)
     def test_start_lucid(self):
         server = Server.start('test', 'ami.lucid')
-        self.assertEqual(server.instance.image_id, 'ami-c7b202ae')
+        self.assertEqual(server.instance.image_id, 'ami-1c6f6174')
 
     @mock.patch('os.mkdir', lambda p: None)
     @mock.patch('profab.connection.EC2Connection', MockConnection)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname1, fname2):
 
 setup(
     name = "profab",
-    version = "0.5",
+    version = "0.5.0.1",
     author = "Proteus Technologies Infrastructure team",
     author_email = "infrastructure@proteus-tech.com",
     url = 'https://github.com/Proteus-tech/profab',


### PR DESCRIPTION
The AMI list from the old location is outdated
change http://uec-images.ubuntu.com/releases
to http://cloud-images.ubuntu.com/locator/ec2/releasesTable instead