### PR TITLE
Fix lucid not found in AMI list

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2016-11-21  Yothin Muangsommuk  <yothin@kmi.tl>
+ Fixed a problem lucid not in AMI list causing error when instance starting up
+
 2015-07-20  Nui Narongwet  <narongwet@proteus-tech.com>
  Download AMI list from up-to-date data source
 

--- a/profab/server.py
+++ b/profab/server.py
@@ -61,7 +61,7 @@ class Server(object):
         config = Configuration(client)
         _logger.info("New server for %s on %s with roles %s",
             config.client, config.host, roles)
-        roles = [('ami.lucid', None), ('bits', None)] + list(roles)
+        roles = [('bits', None)] + list(roles)
         role_adders = cls.get_role_adders(*roles)
 
         # Work out the correct region to use and connect to it

--- a/profab/tests/test_server.py
+++ b/profab/tests/test_server.py
@@ -90,8 +90,8 @@ class ServerLifecycle(TestCase):
         r'''
 { "aaData":
 [
-["us-east-1","lucid","10.04 LTS","amd64","ebs","20150427","<a href=\"https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-1e6f6176\">ami-1e6f6176</a>","aki-919dcaf8"],
-["us-east-1","lucid","10.04 LTS","i386","ebs","20150427","<a href=\"https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-1c6f6174\">ami-1c6f6174</a>","aki-8f9dcae6"],
+["us-east-1","precise","12.04 LTS","amd64","ebs","20161109","<a href=\"https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-f8d4f9ef\">ami-f8d4f9ef</a>","aki-919dcaf8"],
+["us-east-1","precise","12.04 LTS","i386","ebs","20161109","<a href=\"https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-bddaf7aa\">ami-bddaf7aa</a>","aki-8f9dcae6"],
 ]
 }
         ''')
@@ -103,30 +103,9 @@ class ServerLifecycle(TestCase):
     @mock.patch('profab.server.sudo', start_connection)
     @mock.patch('time.sleep', lambda s: None)
     def test_start_customise_bits(self):
-        server = Server.start('test', ('size', 't1.micro'), ('bits', '64'))
+        server = Server.start('test', ('size', 't1.micro'), ('bits', '64'), ('ami.precise', None))
         self.assertEqual(server.instance.instance_type, 't1.micro')
-        self.assertEqual(server.instance.image_id, 'ami-1e6f6176')
-
-    @mock.patch('os.mkdir', lambda p: None)
-    @mock.patch('profab.connection.EC2Connection', MockConnection)
-    @mock.patch('profab.role.ami.ubuntu._fetch_html', lambda u:
-        r'''
-{ "aaData":
-[
-["us-east-1","lucid","10.04 LTS","i386","ebs","20150427","<a href=\"https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-1c6f6174\">ami-1c6f6174</a>","aki-8f9dcae6"],
-]
-}
-        ''')
-    @mock.patch('profab.server.append', start_connection)
-    @mock.patch('profab.server.getaddrinfo', lambda h, p:
-            [(0, 0, 0, '', ('10.56.32.4', p))])
-    @mock.patch('profab.server.reboot', start_connection)
-    @mock.patch('profab.server.run', start_connection)
-    @mock.patch('profab.server.sudo', start_connection)
-    @mock.patch('time.sleep', lambda s: None)
-    def test_start_lucid(self):
-        server = Server.start('test', 'ami.lucid')
-        self.assertEqual(server.instance.image_id, 'ami-1c6f6174')
+        self.assertEqual(server.instance.image_id, 'ami-f8d4f9ef')
 
     @mock.patch('os.mkdir', lambda p: None)
     @mock.patch('profab.connection.EC2Connection', MockConnection)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname1, fname2):
 
 setup(
     name = "profab",
-    version = "0.5.1",
+    version = "0.5.2",
     author = "Proteus Technologies Infrastructure team",
     author_email = "infrastructure@proteus-tech.com",
     url = 'https://github.com/Proteus-tech/profab',


### PR DESCRIPTION
We found out that list of AMI we using here (http://cloud-images.ubuntu.com/locator/ec2/releasesTable) is drop support for lucid, this causing error when we try to starting up new instance. I've remove a bit that add `lucid` to `roles` when start up new instance to fix this